### PR TITLE
Rename to mockito-edgeware and bump version to 1.0.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,22 +6,23 @@ extra = {}
 if sys.version_info >= (3,):
   extra['use_2to3'] = True
 
-setup(name='mockito',
-      version='0.5.1',
+setup(name='mockito-edgeware',
+      version='1.0.0',
       packages=['mockito', 'mockito_test', 'mockito_util'],
-      url='http://code.google.com/p/mockito-python',
-      download_url='http://code.google.com/p/mockito-python/downloads/list',
+      url='https://github.com/edgeware/mockito-python',
+      download_url='http://pypi.edgeware.tv/simple/mockito-edgeware',
       maintainer='Mockito Maintainers',
       maintainer_email='mockito-python@googlegroups.com',
       license='MIT',
       description='Spying framework',
       long_description='Mockito is a spying framework based on Java library with the same name.',
-      classifiers=['Development Status :: 4 - Beta',
-                   'Intended Audience :: Developers',
-                   'License :: OSI Approved :: MIT License',
-                   'Topic :: Software Development :: Testing',
-                   'Programming Language :: Python :: 3'
-                  ],
+      classifiers=[
+          'Development Status :: 4 - Beta',
+          'Intended Audience :: Developers',
+          'License :: OSI Approved :: MIT License',
+          'Topic :: Software Development :: Testing',
+          'Programming Language :: Python :: 3'
+      ],
       test_suite = 'nose.collector',
       py_modules = ['distribute_setup'],
       setup_requires = ['nose'],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(name='mockito-edgeware',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: MIT License',
           'Topic :: Software Development :: Testing',
+          'Programming Language :: Python :: 2'
           'Programming Language :: Python :: 3'
       ],
       test_suite = 'nose.collector',

--- a/setup.py
+++ b/setup.py
@@ -4,18 +4,19 @@ from setuptools import setup
 
 extra = {}
 if sys.version_info >= (3,):
-  extra['use_2to3'] = True
+    extra['use_2to3'] = True
 
-setup(name='mockito-edgeware',
-      version='1.0.0',
+setup(name='mockito',
+      version='0.5.1-edgeware',
       packages=['mockito', 'mockito_test', 'mockito_util'],
       url='https://github.com/edgeware/mockito-python',
-      download_url='http://pypi.edgeware.tv/simple/mockito-edgeware',
+      download_url='http://pypi.edgeware.tv/simple/mockito',
       maintainer='Mockito Maintainers',
       maintainer_email='mockito-python@googlegroups.com',
       license='MIT',
       description='Spying framework',
-      long_description='Mockito is a spying framework based on Java library with the same name.',
+      long_description=('Mockito is a spying framework based on Java library'
+                        'with the same name.'),
       classifiers=[
           'Development Status :: 4 - Beta',
           'Intended Audience :: Developers',
@@ -24,8 +25,7 @@ setup(name='mockito-edgeware',
           'Programming Language :: Python :: 2'
           'Programming Language :: Python :: 3'
       ],
-      test_suite = 'nose.collector',
-      py_modules = ['distribute_setup'],
-      setup_requires = ['nose'],
-      **extra
-)
+      test_suite='nose.collector',
+      py_modules=['distribute_setup'],
+      setup_requires=['nose'],
+      **extra)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ if sys.version_info >= (3,):
     extra['use_2to3'] = True
 
 setup(name='mockito',
-      version='0.5.1-edgeware',
+      version='0.5.1+edgeware',
       packages=['mockito', 'mockito_test', 'mockito_util'],
       url='https://github.com/edgeware/mockito-python',
       download_url='http://pypi.edgeware.tv/simple/mockito',

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ extra = {}
 if sys.version_info >= (3,):
     extra['use_2to3'] = True
 
-setup(name='mockito',
-      version='0.5.1+edgeware',
+setup(name='mockito-edgeware',
+      version='0.5.1',
       packages=['mockito', 'mockito_test', 'mockito_util'],
       url='https://github.com/edgeware/mockito-python',
       download_url='http://pypi.edgeware.tv/simple/mockito',
@@ -22,7 +22,7 @@ setup(name='mockito',
           'Intended Audience :: Developers',
           'License :: OSI Approved :: MIT License',
           'Topic :: Software Development :: Testing',
-          'Programming Language :: Python :: 2'
+          'Programming Language :: Python :: 2',
           'Programming Language :: Python :: 3'
       ],
       test_suite='nose.collector',


### PR DESCRIPTION
Suffixed the package with `-edgeware` so it won't conflict with the original mockito. However the import path will remain the same but you install it with:

```
$ pip install mockito-edgeware
```
